### PR TITLE
Fix typo in template

### DIFF
--- a/templates/slapd.ldiff.j2
+++ b/templates/slapd.ldiff.j2
@@ -60,7 +60,7 @@ olcDatabase: {1}mdb
 olcDbDirectory: /var/openldap/data
 olcSuffix: {{ openldap_base }}
 olcRootDN: cn=admin,{{ openldap_base }}
-{% if openldap_password_hash is defined %}olcRootPW: {{ openldap_password_hash }}{{% endif %}
+{% if openldap_password_hash is defined %}olcRootPW: {{ openldap_password_hash }}{% endif %}
 olcAccess: to attrs=userPassword
            by anonymous auth
            by self =xw


### PR DESCRIPTION
fixes a templating error in `templates/slapd.ldiff.j2`:
```
TASK [openldap : create openldap config] *****************************************************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: {% endfor %}
fatal: [main]: FAILED! => {
    "changed": false
}

MSG:

AnsibleError: template error while templating string: unexpected '%'. String: dn: cn=config
[...]
```